### PR TITLE
Hw17 sql init

### DIFF
--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,0 +1,25 @@
+CREATE TABLE Homework (
+                          id SMALLINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+                          name VARCHAR(20) NOT NULL,
+                          description TEXT NOT NULL
+);
+
+CREATE TABLE Lesson (
+                        id SMALLINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+                        name VARCHAR(20) NOT NULL,
+                        updated_at DATETIME NOT NULL,
+                        homework_id INT,
+                        FOREIGN KEY (homework_id) REFERENCES Homework(id)
+);
+
+CREATE TABLE Schedule (
+                          id SMALLINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+                          name VARCHAR(20) NOT NULL,
+                          updateAt DATETIME NOT NULL
+);
+
+CREATE TABLE Schedule_Lesson (
+                                 schedule_id SMALLINT REFERENCES schedule (id) ON DELETE CASCADE,
+                                 lesson_id   SMALLINT REFERENCES lesson (id) ON DELETE CASCADE,
+                                 PRIMARY KEY (schedule_id, lesson_id)
+);


### PR DESCRIPTION
#hw17
- Created `init.sql` to set up the Homework, Lesson, Schedule, and Schedule_Lesson tables with primary keys, foreign keys, and cascading deletes.